### PR TITLE
feat: Add time and word options to typing test

### DIFF
--- a/src/lib/typingTexts.ts
+++ b/src/lib/typingTexts.ts
@@ -40,3 +40,16 @@ export function getRandomText(lang: "fr" | "en" = "fr"): string {
   const langTexts = typingTexts[lang];
   return langTexts[Math.floor(Math.random() * langTexts.length)];
 }
+
+export function getRandomWords(
+  count: number,
+  lang: "fr" | "en" = "fr"
+): string {
+  const langTexts = typingTexts[lang];
+  const allWords = langTexts.join(" ").split(" ");
+  let result = "";
+  for (let i = 0; i < count; i++) {
+    result += allWords[Math.floor(Math.random() * allWords.length)] + " ";
+  }
+  return result.trim();
+}


### PR DESCRIPTION
This commit introduces the ability for users to choose between different test modes in the Typing Test: by time or by number of words.

- Added a new  function to  to generate a specific number of random words.
- Updated  with UI elements to allow users to select the test mode (time or words) and choose from a set of predefined options (e.g., 15s, 30s, 10 words, 25 words).
- The game logic has been updated to handle both test modes, ending the test based on either the selected duration or the number of words typed.
- The WPM calculation has been adjusted to work correctly for both modes.