### PR TITLE
feat: Add new themes

### DIFF
--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,23 +1,54 @@
-import { Moon, Sun } from 'lucide-react';
+import { Moon, Sun, Palette } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useTheme } from '@/hooks/useTheme';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
 
 export function ThemeToggle() {
-  const { theme, toggleTheme } = useTheme();
+  const { setTheme, toggleMode, mode } = useTheme();
 
   return (
-    <Button
-      variant="ghost"
-      size="icon"
-      onClick={toggleTheme}
-      className="h-9 w-9 rounded-lg transition-colors hover:bg-secondary"
-      aria-label={theme === 'light' ? 'Activer le mode sombre' : 'Activer le mode clair'}
-    >
-      {theme === 'light' ? (
-        <Moon className="h-4 w-4 text-muted-foreground" />
-      ) : (
-        <Sun className="h-4 w-4 text-muted-foreground" />
-      )}
-    </Button>
+    <div className="flex items-center gap-2">
+      <Button
+        variant="ghost"
+        size="icon"
+        onClick={toggleMode}
+        className="h-9 w-9 rounded-lg"
+      >
+        <Sun className="h-4 w-4 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+        <Moon className="absolute h-4 w-4 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+        <span className="sr-only">Toggle light/dark mode</span>
+      </Button>
+
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="ghost" size="icon" className="h-9 w-9 rounded-lg">
+            <Palette className="h-4 w-4" />
+            <span className="sr-only">Select color theme</span>
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem onClick={() => setTheme('light')}>
+            Default
+          </DropdownMenuItem>
+          <DropdownMenuItem onClick={() => setTheme('blue')}>
+            Blue
+          </DropdownMenuItem>
+          <DropdownMenuItem onClick={() => setTheme('green')}>
+            Green
+          </DropdownMenuItem>
+          <DropdownMenuItem onClick={() => setTheme('orange')}>
+            Orange
+          </DropdownMenuItem>
+          <DropdownMenuItem onClick={() => setTheme('purple')}>
+            Purple
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+    </DropdownMenu>
+    </div>
   );
 }

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,11 +1,19 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 
-type Theme = 'light' | 'dark';
+type Theme = 'light' | 'blue' | 'green' | 'orange' | 'purple';
+type Mode = 'light' | 'dark';
 
 export function useTheme() {
-  const [theme, setTheme] = useState<Theme>(() => {
+  const [theme, _setTheme] = useState<Theme>(() => {
     if (typeof window !== 'undefined') {
-      const stored = localStorage.getItem('theme') as Theme;
+      return (localStorage.getItem('color-theme') as Theme) || 'light';
+    }
+    return 'light';
+  });
+
+  const [mode, _setMode] = useState<Mode>(() => {
+    if (typeof window !== 'undefined') {
+      const stored = localStorage.getItem('theme-mode') as Mode;
       if (stored) return stored;
       return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
     }
@@ -14,14 +22,29 @@ export function useTheme() {
 
   useEffect(() => {
     const root = document.documentElement;
+    
+    // Set dark/light mode
     root.classList.remove('light', 'dark');
-    root.classList.add(theme);
-    localStorage.setItem('theme', theme);
-  }, [theme]);
+    root.classList.add(mode);
 
-  const toggleTheme = () => {
-    setTheme(prev => prev === 'light' ? 'dark' : 'light');
+    // Set color theme
+    root.setAttribute('data-theme', theme);
+    
+    localStorage.setItem('color-theme', theme);
+    localStorage.setItem('theme-mode', mode);
+  }, [theme, mode]);
+  
+  const setTheme = useCallback((newTheme: Theme) => {
+    _setTheme(newTheme);
+  }, []);
+
+  const setMode = useCallback((newMode: Mode) => {
+    _setMode(newMode);
+  }, []);
+
+  const toggleMode = () => {
+    _setMode(prev => prev === 'light' ? 'dark' : 'light');
   };
 
-  return { theme, setTheme, toggleTheme };
+  return { theme, setTheme, mode, setMode, toggleMode };
 }

--- a/src/index.css
+++ b/src/index.css
@@ -114,6 +114,86 @@
     --sidebar-border: 220 15% 18%;
     --sidebar-ring: 200 35% 55%;
   }
+
+  [data-theme='blue'] {
+    --background: 210 40% 98%;
+    --foreground: 215 25% 25%;
+    --card: 210 40% 100%;
+    --primary: 220 90% 60%;
+    --primary-foreground: 210 40% 98%;
+    --secondary: 210 40% 96%;
+    --accent: 210 40% 94%;
+  }
+
+  .dark[data-theme='blue'] {
+    --background: 220 20% 10%;
+    --foreground: 210 40% 98%;
+    --card: 220 20% 12%;
+    --primary: 220 80% 65%;
+    --primary-foreground: 220 20% 10%;
+    --secondary: 220 20% 15%;
+    --accent: 220 20% 18%;
+  }
+
+  [data-theme='green'] {
+    --background: 140 20% 98%;
+    --foreground: 140 25% 25%;
+    --card: 140 20% 100%;
+    --primary: 150 70% 40%;
+    --primary-foreground: 140 20% 98%;
+    --secondary: 140 20% 96%;
+    --accent: 140 20% 94%;
+  }
+
+  .dark[data-theme='green'] {
+    --background: 150 20% 10%;
+    --foreground: 140 20% 98%;
+    --card: 150 20% 12%;
+    --primary: 150 60% 50%;
+    --primary-foreground: 150 20% 10%;
+    --secondary: 150 20% 15%;
+    --accent: 150 20% 18%;
+  }
+
+  [data-theme='orange'] {
+    --background: 30 100% 97%;
+    --foreground: 20 20% 20%;
+    --card: 30 100% 100%;
+    --primary: 35 100% 55%;
+    --primary-foreground: 20 20% 5%;
+    --secondary: 30 100% 95%;
+    --accent: 30 100% 93%;
+  }
+
+  .dark[data-theme='orange'] {
+    --background: 20 20% 10%;
+    --foreground: 30 100% 97%;
+    --card: 20 20% 12%;
+    --primary: 35 90% 60%;
+    --primary-foreground: 20 20% 5%;
+    --secondary: 20 20% 15%;
+    --accent: 20 20% 18%;
+  }
+
+  [data-theme='purple'] {
+    --background: 270 50% 98%;
+    --foreground: 270 30% 20%;
+    --card: 270 50% 100%;
+    --primary: 260 70% 60%;
+    --primary-foreground: 270 50% 98%;
+    --secondary: 270 50% 96%;
+    --accent: 270 50% 94%;
+  }
+
+  .dark[data-theme='purple'] {
+    --background: 270 30% 10%;
+    --foreground: 270 50% 98%;
+    --card: 270 30% 12%;
+    --primary: 260 70% 65%;
+    --primary-foreground: 270 30% 10%;
+    --secondary: 270 30% 15%;
+    --accent: 270 30% 18%;
+  }
 }
 
 @layer base {


### PR DESCRIPTION
This commit introduces new color themes to the application, allowing users to personalize their experience.

- Restructured the CSS in  to use  attributes for better theme management and light/dark mode variants.
- Added 'blue', 'green', 'orange', and 'purple' color themes, each with distinct light and dark palettes.
- Updated the  hook to manage separate color themes and light/dark modes, and to apply the correct classes and data attributes to the  element.
- Modified the  component to feature a dropdown for selecting the color theme and a separate button for toggling between light and dark modes.