### PR TITLE
feat: Add Time Perception test

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import ReflexTest from "./pages/ReflexTest";
 import TypingTest from "./pages/TypingTest";
 import Performance from "./pages/Performance";
+import TimePerceptionTest from "./pages/TimePerception";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -21,6 +22,7 @@ const App = () => (
           <Route path="/reflexes" element={<ReflexTest />} />
           <Route path="/typing" element={<TypingTest />} />
           <Route path="/performance" element={<Performance />} />
+          <Route path="/time-perception" element={<TimePerceptionTest />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,7 +1,7 @@
 import { NavLink } from 'react-router-dom';
 import { ThemeToggle } from './ThemeToggle';
 import { cn } from '@/lib/utils';
-import { Zap, Keyboard, BarChart } from 'lucide-react';
+import { Zap, Keyboard, BarChart, Hourglass } from 'lucide-react';
 
 interface LayoutProps {
   children: React.ReactNode;
@@ -54,6 +54,20 @@ export function Layout({ children }: LayoutProps) {
             >
               <BarChart className="h-4 w-4" />
               <span>Performance</span>
+            </NavLink>
+            <NavLink
+              to="/time-perception"
+              className={({ isActive }) =>
+                cn(
+                  "flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium transition-all",
+                  isActive
+                    ? "bg-secondary text-foreground"
+                    : "text-muted-foreground hover:text-foreground hover:bg-secondary/50"
+                )
+              }
+            >
+              <Hourglass className="h-4 w-4" />
+              <span>Time Perception</span>
             </NavLink>
           </div>
           <ThemeToggle />

--- a/src/index.css
+++ b/src/index.css
@@ -261,4 +261,20 @@
       transform: scale(1);
     }
   }
+  
+  /* Breathing animation for time perception test */
+  .animate-breathing {
+    animation: breathing 4s ease-in-out infinite;
+  }
+
+  @keyframes breathing {
+    0%, 100% {
+      transform: scale(1);
+      opacity: 0.8;
+    }
+    50% {
+      transform: scale(1.05);
+      opacity: 1;
+    }
+  }
 }

--- a/src/pages/Performance.tsx
+++ b/src/pages/Performance.tsx
@@ -10,6 +10,7 @@ import { Button } from '@/components/ui/button';
 const initialHistory: PerformanceHistory = {
   reflex: [],
   typing: [],
+  timePerception: [],
 };
 
 export default function Performance() {
@@ -35,6 +36,15 @@ export default function Performance() {
     date: new Date(r.date).toLocaleDateString(),
     time: r.time,
   })).reverse();
+
+  const bestTimePerception = history.timePerception?.length > 0 ? Math.min(...history.timePerception.map(r => Math.abs(r.difference))) : 0;
+  const averageTimePerception = history.timePerception?.length > 0
+    ? (history.timePerception.reduce((acc, r) => acc + r.difference, 0) / history.timePerception.length)
+    : 0;
+  const timePerceptionChartData = history.timePerception?.map(r => ({
+    date: new Date(r.date).toLocaleDateString(),
+    difference: r.difference,
+  })).reverse() || [];
 
 
   const handleSave = () => {
@@ -63,10 +73,10 @@ export default function Performance() {
           </div>
         </div>
 
-        <div className="grid md:grid-cols-2 gap-8">
+        <div className="grid md:grid-cols-3 gap-8">
           <div>
             <h2 className="text-xl font-bold mb-4">Typing</h2>
-            <div className="grid md:grid-cols-3 gap-6 mb-8">
+            <div className="grid grid-cols-1 gap-6 mb-8">
               <Card>
                 <CardHeader>
                   <CardTitle>Best WPM</CardTitle>
@@ -142,7 +152,7 @@ export default function Performance() {
 
           <div>
             <h2 className="text-xl font-bold mb-4">Reflex</h2>
-            <div className="grid md:grid-cols-2 gap-6 mb-8">
+            <div className="grid grid-cols-1 gap-6 mb-8">
               <Card>
                 <CardHeader>
                   <CardTitle>Best Time</CardTitle>
@@ -198,6 +208,74 @@ export default function Performance() {
                       <TableRow key={result.id}>
                         <TableCell>{new Date(result.date).toLocaleString()}</TableCell>
                         <TableCell>{result.time}</TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </CardContent>
+            </Card>
+          </div>
+          
+          <div>
+            <h2 className="text-xl font-bold mb-4">Time Perception</h2>
+            <div className="grid grid-cols-1 gap-6 mb-8">
+              <Card>
+                <CardHeader>
+                  <CardTitle>Best Score</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <p className="text-4xl font-bold">{bestTimePerception.toFixed(2)}s</p>
+                </CardContent>
+              </Card>
+              <Card>
+                <CardHeader>
+                  <CardTitle>Average Difference</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <p className="text-4xl font-bold">{averageTimePerception.toFixed(2)}s</p>
+                </CardContent>
+              </Card>
+            </div>
+
+            <Card className="mb-8">
+              <CardHeader>
+                <CardTitle>Difference Over Time</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <ChartContainer config={{}} className="h-64 w-full">
+                  <AreaChart data={timePerceptionChartData}>
+                    <CartesianGrid strokeDasharray="3 3" />
+                    <XAxis dataKey="date" />
+                    <YAxis />
+                    <ChartTooltip
+                      cursor={false}
+                      content={<ChartTooltipContent indicator="dot" />}
+                    />
+                    <Area type="monotone" dataKey="difference" fill="var(--color-primary)" stroke="var(--color-primary)" />
+                  </AreaChart>
+                </ChartContainer>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle>Time Perception History</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Date</TableHead>
+                      <TableHead>Time (s)</TableHead>
+                      <TableHead>Difference (s)</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {history.timePerception?.map(result => (
+                      <TableRow key={result.id}>
+                        <TableCell>{new Date(result.date).toLocaleString()}</TableCell>
+                        <TableCell>{result.time.toFixed(2)}</TableCell>
+                        <TableCell>{result.difference.toFixed(2)}</TableCell>
                       </TableRow>
                     ))}
                   </TableBody>

--- a/src/pages/TimePerception.tsx
+++ b/src/pages/TimePerception.tsx
@@ -1,0 +1,109 @@
+import { useState, useCallback } from 'react';
+import { Layout } from '@/components/Layout';
+import { cn } from '@/lib/utils';
+import { Dot } from 'lucide-react';
+import { useLocalStorage } from '@/hooks/useLocalStorage';
+import type { PerformanceHistory, TimePerceptionResult } from '@/types/history';
+import { Button } from '@/components/ui/button';
+
+type GameState = 'idle' | 'running' | 'result';
+
+const initialHistory: PerformanceHistory = {
+  reflex: [],
+  typing: [],
+  timePerception: [],
+};
+
+export default function TimePerceptionTest() {
+  const [gameState, setGameState] = useState<GameState>('idle');
+  const [startTime, setStartTime] = useState<number>(0);
+  const [result, setResult] = useState<number>(0);
+  const [history, setHistory] = useLocalStorage<PerformanceHistory>('performance-history', initialHistory);
+
+  const handleClick = useCallback(() => {
+    if (gameState === 'idle') {
+      setStartTime(performance.now());
+      setGameState('running');
+    } else if (gameState === 'running') {
+      const endTime = performance.now();
+      const duration = (endTime - startTime) / 1000;
+      setResult(duration);
+      setGameState('result');
+      
+      const newResult: TimePerceptionResult = {
+        id: crypto.randomUUID(),
+        time: duration,
+        difference: duration - 10,
+        date: new Date().toISOString(),
+      };
+
+      setHistory(prev => ({
+        ...prev,
+        timePerception: [newResult, ...(prev.timePerception || [])].slice(0, 10),
+      }));
+
+    } else { // gameState === 'result'
+      setGameState('idle');
+      setResult(0);
+    }
+  }, [gameState, startTime, setHistory]);
+
+  const difference = result - 10;
+
+  const getResultMessage = () => {
+    const diff = Math.abs(difference);
+    if (diff <= 0.1) return "Incroyable!";
+    if (diff <= 0.5) return "Excellent!";
+    if (result < 9.5) return "Un peu trop vite";
+    if (result > 10.5) return "Un peu trop lent";
+    return "Bien essayé!";
+  };
+
+  return (
+    <Layout>
+      <div className="flex flex-col items-center justify-center h-full p-4 text-center">
+        
+        <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-full">
+          {gameState === 'result' ? (
+             <div className="text-center animate-fade-in">
+               <h2 className="text-8xl font-bold tracking-tighter">{result.toFixed(2)}s</h2>
+               <p className="text-3xl text-muted-foreground font-light">
+                 ({difference > 0 ? '+' : ''}{difference.toFixed(2)}s)
+               </p>
+               <p className="text-2xl mt-6 font-medium">{getResultMessage()}</p>
+             </div>
+          ) : (
+            <div className="flex justify-center items-center">
+              <button 
+                onClick={handleClick}
+                className={cn(
+                  "relative w-48 h-48 rounded-full transition-all duration-500 ease-in-out",
+                  "flex items-center justify-center",
+                  "bg-sage-300",
+                  "text-2xl font-semibold text-sage-800",
+                  gameState === 'running' ? 'animate-breathing' : 'hover:bg-sage-400',
+                )}
+              >
+                {gameState === 'idle' && 'Start'}
+                {gameState === 'running' && <Dot className="w-16 h-16" />}
+              </button>
+            </div>
+          )}
+        </div>
+
+        <div className="absolute bottom-20 text-center">
+          {gameState === 'idle' && (
+            <div className="animate-fade-in">
+              <h1 className="text-xl font-semibold mb-1">Perception du Temps</h1>
+              <p className="text-muted-foreground">Cliquez, puis arrêtez à exactement 10 secondes.</p>
+            </div>
+          )}
+          {gameState === 'result' && (
+            <Button onClick={handleClick} variant="ghost" className="animate-fade-in">Réessayer</Button>
+          )}
+        </div>
+
+      </div>
+    </Layout>
+  );
+}

--- a/src/types/history.ts
+++ b/src/types/history.ts
@@ -11,11 +11,21 @@ export interface TypingResult {
   date: string; // ISO string
 }
 
+export interface TimePerceptionResult {
+  id: string;
+  time: number; // in seconds
+  difference: number; // in seconds
+  date: string; // ISO string
+}
+
 export type ReflexHistory = ReflexResult[];
 
 export type TypingHistory = TypingResult[];
 
+export type TimePerceptionHistory = TimePerceptionResult[];
+
 export interface PerformanceHistory {
   reflex: ReflexHistory;
   typing: TypingHistory;
+  timePerception: TimePerceptionHistory;
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -68,6 +68,17 @@ export default {
           border: "hsl(var(--sidebar-border))",
           ring: "hsl(var(--sidebar-ring))",
         },
+        sage: {
+          100: "#f0f2f0",
+          200: "#d9e0d7",
+          300: "#c3cdc1",
+          400: "#adb9ac",
+          500: "#97a697",
+          600: "#819282",
+          700: "#6b7e6d",
+          800: "#556a58",
+          900: "#3f5643",
+        },
       },
       borderRadius: {
         lg: "var(--radius)",


### PR DESCRIPTION
This commit introduces a new 'Time Perception' test to the application, allowing users to test their internal clock.

- **New Component**: Created  with a minimalist, 'Zen' aesthetic as requested.
- **Game Logic**: Implemented the core mechanic where the user starts a timer, mentally counts to 10 seconds, and stops it. The result, difference, and a contextual message are displayed.
- **Styling**:
  - Added a 'breathing' animation for the active state.
  - Added a 'sage' color palette to  for the button and UI elements.
- **Routing & Navigation**:
  - Added a new route for  in .
  - Added a navigation link in the main layout with an  icon.
- **History & Performance**:
  - Updated  to include types for time perception results.
  - The  page now displays statistics, a chart, and a history table for the Time Perception test.